### PR TITLE
Not allowing empty config

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -46,7 +46,8 @@ func ReadConfig() (*Config, error) {
 		}
 		return &conf, nil
 	}
-	return &Config{}, nil
+
+	return nil, errors.New("Config file not found")
 }
 
 type SlackMsg struct {


### PR DESCRIPTION
Before:

```
[slackcat] % ./bin/slackcat wtf
2014/05/12 18:07:58 Post failed: Post : unsupported protocol scheme ""
```

After:

```
[slackcat] % ./bin/slackcat wtf
2014/05/12 18:08:05 Could not read config: Config file not found
```

Much more clear if you ask me :)
