### PR TITLE
Printing actual http error, closing response body

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 
 	"github.com/ogier/pflag"
+	"io/ioutil"
 )
 
 type Config struct {
@@ -78,8 +79,15 @@ func (m SlackMsg) Post(WebhookURL string) error {
 		return err
 	}
 
+	defer resp.Body.Close()
+
 	if resp.StatusCode != http.StatusOK {
-		return errors.New("Not OK")
+		body, err := ioutil.ReadAll(resp.Body)
+		if err != nil {
+			return err
+		}
+
+		return errors.New(fmt.Sprintf("Not OK: %d, %s", resp.StatusCode, body))
 	}
 	return nil
 }


### PR DESCRIPTION
Before:

```
2014/05/21 18:33:21 Post failed: Not OK
```

After:

```
2014/05/21 18:37:00 Post failed: Not OK: 500, No text specified
```

Also, response body should be closed since it is `io.ReadCloser`.

Probably you should update readme too, following files with empty lines will cause http error 500:

```
tail -F logfile | slackcat
```

will trigger error above, when:

```
tail -F logfile | grep --line-buffered -v '^\s*$' | slackcat
```

will work just fine.
