### PR TITLE
Allow config through environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,15 +10,23 @@ If you have a working go installation run `go get github.com/paulhammond/slackca
 
 ## Configuring
 
-First, create a [new Slack Incoming Webhook integration][new-webhook].
+To use slackcat you must create a [Slack Incoming Webhook integration][new-webhook].
 
-Then create a `/etc/slackcat.conf` file, and add your new webhook url:
+You can configure slackcat through a config file or environment variables (the latter overriding the former).
+
+Only `webhook_url` is required, `channel`, `username`, and `icon_emoji` are optional, and will be used if not supplied as a command line option.
+
+### Environment Variable
+
+    $ export SLACKCAT_WEBHOOK_URL=https://my.slack.com/services/hooks/incoming-webhook?token=token
+
+### Config File
 
     {
         "webhook_url":"https://my.slack.com/services/hooks/incoming-webhook?token=token"
     }
 
-If you don't have permission to create `/etc/slackcat.conf` then you can create `~/.slackcat.conf` instead.
+In either `/etc/slackcat.conf`, `~/.slackcat.conf`, or `./slackcat.conf`.
 
 ## Usage
 
@@ -37,6 +45,10 @@ By default slackcat will post each message as coming from "user@hostname". If yo
 Slackcat will use the channel specified when you set up the incoming webhook. You can override this in the config file by adding a "channel" option, or you can use the `--channel` flag:
 
     echo "testing" | slackcat --channel #test
+
+You can set an avatar using an [emoji string](http://www.emoji-cheat-sheet.com/):
+
+    echo "we're watching you" | slackcat --icon=:family:
 
 
 

--- a/slackcat.go
+++ b/slackcat.go
@@ -20,10 +20,46 @@ import (
 type Config struct {
 	WebhookUrl string  `json:"webhook_url"`
 	Channel    string  `json:"channel"`
-	Username   *string `json:"username"`
+	Username   string  `json:"username"`
+	IconEmoji  string  `json:"icon_emoji"`
 }
 
-func ReadConfig() (*Config, error) {
+func (c *Config) Load() error {
+	err := c.loadConfigFiles()
+	if err != nil {
+		return err
+	}
+	c.loadEnvVars()
+
+	if c.WebhookUrl == "" {
+		return errors.New("Could not find a WebhookUrl in SLACKCAT_WEBHOOK_URL, /etc/slackcat.conf, /.slackcat.conf, ./slackcat.conf")
+	}
+
+	return nil
+}
+
+func (c *Config) loadEnvVars() {
+	envs := []string{"SLACKCAT_WEBHOOK_URL", "SLACKCAT_CHANNEL", "SLACKCAT_USERNAME", "SLACKCAT_ICON"}
+	for _,env := range envs {
+		envVal := os.Getenv(env)
+		if envVal == "" {
+			continue
+		}
+
+		switch env {
+		case "SLACKCAT_WEBHOOK_URL":
+			c.WebhookUrl = envVal
+		case "SLACKCAT_CHANNEL":
+			c.Channel = envVal
+		case "SLACKCAT_USERNAME":
+			c.Username = envVal
+		case "SLACKCAT_ICON":
+			c.IconEmoji = envVal
+		}
+	}
+}
+
+func (c *Config) loadConfigFiles() error {
 	homeDir := ""
 	usr, err := user.Current()
 	if err == nil {
@@ -36,19 +72,16 @@ func ReadConfig() (*Config, error) {
 			continue
 		}
 		if err != nil {
-			return nil, err
+			return err
 		}
 
-		json.NewDecoder(file)
-		conf := Config{}
-		err = json.NewDecoder(file).Decode(&conf)
+		err = json.NewDecoder(file).Decode(c)
 		if err != nil {
-			return nil, err
+			return err
 		}
-		return &conf, nil
 	}
 
-	return nil, errors.New("Config file not found")
+	return nil
 }
 
 type SlackMsg struct {
@@ -84,7 +117,7 @@ func (m SlackMsg) Post(WebhookURL string) error {
 	return nil
 }
 
-func username() string {
+func defaultUsername() string {
 	username := "<unknown>"
 	usr, err := user.Current()
 	if err == nil {
@@ -100,18 +133,10 @@ func username() string {
 }
 
 func main() {
-
-	cfg, err := ReadConfig()
+	cfg := Config{Username: defaultUsername()}
+	err := cfg.Load()
 	if err != nil {
-		log.Fatalf("Could not read config: %v", err)
-	}
-
-	// By default use "user@server", unless overridden by config. cfg.Username
-	// can be "", implying Slack should use the default username, so we have
-	// to check if the value was set, not just for a non-empty string.
-	defaultName := username()
-	if cfg.Username != nil {
-		defaultName = *cfg.Username
+		log.Fatalf("Failed to load config: %v", err)
 	}
 
 	pflag.Usage = func() {
@@ -119,8 +144,8 @@ func main() {
 	}
 
 	channel := pflag.StringP("channel", "c", cfg.Channel, "channel")
-	name := pflag.StringP("name", "n", defaultName, "name")
-	icon := pflag.StringP("icon", "i", "", "icon")
+	name := pflag.StringP("name", "n", cfg.Username, "name") // TODO: username or name?
+	icon := pflag.StringP("icon", "i", cfg.IconEmoji, "icon")
 	pflag.Parse()
 
 	// was there a message on the command line? If so use it.
@@ -157,7 +182,7 @@ func main() {
 			log.Fatalf("Post failed: %v", err)
 		}
 	}
-	if err := scanner.Err(); err != nil {
+	if err = scanner.Err(); err != nil {
 		log.Fatalf("Error reading: %v", err)
 	}
 }


### PR DESCRIPTION
_Initial PR was on my master branch, but I have more changes to make..._

We store and manage keys for tools like slackcat through environment variables. It an easy way for us to provision servers while keeping packages public. I figured this would be a useful addition to the project, so I've added support for it.

The first commit adds some methods to the Config struct containing this change. I wanted config options to cascade so that base options can be overridden by env vars (or other config files). The second commit makes handling CLI flags a configuration concern. I've kept it separate in case you would rather it worked a different way.

I've noticed some inconsistencies between username and name, icon and icon_emoji. It'd be good to make these more consistent, but I thought I'd let you make that call (are you bothered about backwards compatibility?)

Cheers
-a
