### PR TITLE
Removed `parse` parameter

### DIFF
--- a/slackcat.go
+++ b/slackcat.go
@@ -55,7 +55,6 @@ type SlackMsg struct {
 	Channel   string `json:"channel"`
 	Username  string `json:"username,omitempty"`
 	Text      string `json:"text"`
-	Parse     string `json:"parse"`
 	IconEmoji string `json:"icon_emoji,omitempty"`
 }
 
@@ -129,7 +128,6 @@ func main() {
 		msg := SlackMsg{
 			Channel:   *channel,
 			Username:  *name,
-			Parse:     "full",
 			Text:      strings.Join(args, " "),
 			IconEmoji: *icon,
 		}
@@ -147,7 +145,6 @@ func main() {
 		msg := SlackMsg{
 			Channel:   *channel,
 			Username:  *name,
-			Parse:     "full",
 			Text:      scanner.Text(),
 			IconEmoji: *icon,
 		}


### PR DESCRIPTION
> If you want Slack to treat your message as completely unformatted, pass parse=full.
> This will ignore any markup formatting you added to your message.
> https://api.slack.com/docs/formatting#parsing_modes

So I just completly removed `parse` parameter.

To test my changes I've created a `messages.txt` file:

```
first plain text message
second message with <http://google.com/|link>
```

And run `cat messages.txt | go run slackcat.go` twice (in master and in my branch). This is the results:
![slack](https://cloud.githubusercontent.com/assets/7838144/12605406/cb7a8ed6-c4d5-11e5-9309-54de4f3b3cec.png)
The first 2 messages - master, the last 2 - with my changes.

cc @paulhammond 

Fixes #12
